### PR TITLE
update PropTypes usage, devDeps to ensure tests run locally

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,7 @@
 {
-  "presets": ["netflix-dea"]
+  "presets": ["latest", "stage-2"],
+  "plugins": [
+    "add-module-exports",
+    "transform-react-jsx",
+  ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,20 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
   - "stable"
+  - "5"
+  - "4"
 sudo: false
+env: REACT_VERSION=15.5.x
+matrix:
+  include:
+    # These versions run different jobs in which we `npm install` other releases
+    # of react (& friends) to run our test suite against those as well
+    - env: REACT_VERSION=0.14.9 REACT_ADDONS_TEST_UTILS_VERSION=^0.14.x
+    # testing the base 15 release
+    - env: REACT_VERSION=15.0.0 REACT_ADDONS_TEST_UTILS_VERSION=15.0.0
+    # testing the current highest supported release
+    - env: REACT_VERSION=15.5.4 REACT_ADDONS_TEST_UTILS_VERSION=15.5.1
+cache: npm
+install:
+  - npm install
+  - npm install react@$REACT_VERSION react-dom@$REACT_VERSION react-addons-test-utils@$REACT_ADDONS_TEST_UTILS_VERSION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ make it easier to update and read.
 ## [Unreleased]
 _(add items here to be added to future release)_
 
+## 3.0.0-beta 2017-04-26
+### Added
+- Support for React 15.5 💯
+  - `peerDependencies` now includes `prop-types` 🎉.
+  - I don't have a strategy yet for you to only include that in development, and
+  strip PropTypes in prod bundles, but that is what you should do especially if size is a concern.
+
+### Changed
+- Updated devDependencies for mocha & babel-register 👍
+- Update Travis CI matrix to test against a wider variety of
+node and react versions.
+
 ## 2.0.1 2017-04-03
 ### Added
 - Tests for `<Text/>` that assert it can work with larger, nested bundles by default

--- a/build/Localization.js
+++ b/build/Localization.js
@@ -14,6 +14,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _localizeFormatter = require('./util/localize-formatter');
 
 var _localizeFormatter2 = _interopRequireDefault(_localizeFormatter);
@@ -26,10 +30,10 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var element = _react.PropTypes.element;
-var bool = _react.PropTypes.bool;
-var func = _react.PropTypes.func;
-var object = _react.PropTypes.object;
+var element = _propTypes2.default.element,
+    bool = _propTypes2.default.bool,
+    func = _propTypes2.default.func,
+    object = _propTypes2.default.object;
 
 var Localization = function (_React$Component) {
   _inherits(Localization, _React$Component);
@@ -37,7 +41,7 @@ var Localization = function (_React$Component) {
   function Localization(props, context) {
     _classCallCheck(this, Localization);
 
-    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(Localization).call(this, props, context));
+    var _this = _possibleConstructorReturn(this, (Localization.__proto__ || Object.getPrototypeOf(Localization)).call(this, props, context));
 
     _this.localize = _this.localize.bind(_this);
     return _this;
@@ -55,9 +59,9 @@ var Localization = function (_React$Component) {
     key: 'localize',
     value: function localize(key, values) {
       values = values || [];
-      var _props = this.props;
-      var messages = _props.messages;
-      var xLocale = _props.xLocale;
+      var _props = this.props,
+          messages = _props.messages,
+          xLocale = _props.xLocale;
 
 
       if (xLocale) {

--- a/build/LocalizationConnector.js
+++ b/build/LocalizationConnector.js
@@ -10,12 +10,16 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 exports.default = function (ComposedComponent) {
   var LocalizeConnected = function LocalizeConnected(props, context) {
-    var localize = context.localize;
-    var _localizeDebug = context._localizeDebug;
+    var localize = context.localize,
+        _localizeDebug = context._localizeDebug;
 
 
     var connectedLocalizer = localize;
@@ -37,7 +41,7 @@ exports.default = function (ComposedComponent) {
 
   LocalizeConnected.displayName = 'ReactLocalized(' + ComposedComponent.name + ')';
   LocalizeConnected.contextTypes = {
-    localize: _react.PropTypes.func
+    localize: _propTypes2.default.func
   };
 
   return LocalizeConnected;

--- a/build/LocalizationWrapper.js
+++ b/build/LocalizationWrapper.js
@@ -12,6 +12,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _lodash = require('lodash.get');
 
 var _lodash2 = _interopRequireDefault(_lodash);
@@ -29,7 +33,7 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 exports.default = function (ComposedComponent) {
-  var messages = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+  var messages = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
   var customLocalizer = arguments[2];
 
   var ConfigureLocalization = function (_Component) {
@@ -38,7 +42,7 @@ exports.default = function (ComposedComponent) {
     function ConfigureLocalization() {
       _classCallCheck(this, ConfigureLocalization);
 
-      return _possibleConstructorReturn(this, Object.getPrototypeOf(ConfigureLocalization).apply(this, arguments));
+      return _possibleConstructorReturn(this, (ConfigureLocalization.__proto__ || Object.getPrototypeOf(ConfigureLocalization)).apply(this, arguments));
     }
 
     _createClass(ConfigureLocalization, [{
@@ -70,7 +74,7 @@ exports.default = function (ComposedComponent) {
   }(_react.Component);
 
   ConfigureLocalization.displayName = 'Wrapped' + (ComposedComponent.displayName || ComposedComponent.name || 'Component');
-  ConfigureLocalization.childContextTypes = _extends({}, ComposedComponent.childContextTypes, { localize: _react.PropTypes.func });
+  ConfigureLocalization.childContextTypes = _extends({}, ComposedComponent.childContextTypes, { localize: _propTypes2.default.func });
 
   return ConfigureLocalization;
 };

--- a/build/Text.js
+++ b/build/Text.js
@@ -8,25 +8,28 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-var arrayOf = _react.PropTypes.arrayOf;
-var bool = _react.PropTypes.bool;
-var func = _react.PropTypes.func;
-var string = _react.PropTypes.string;
-var any = _react.PropTypes.any;
+var arrayOf = _propTypes2.default.arrayOf,
+    bool = _propTypes2.default.bool,
+    func = _propTypes2.default.func,
+    string = _propTypes2.default.string,
+    any = _propTypes2.default.any;
 
 
 var Text = function Text(props, context) {
-  var message = props.message;
-  var values = props.values;
+  var message = props.message,
+      values = props.values,
+      rest = _objectWithoutProperties(props, ['message', 'values']);
 
-  var rest = _objectWithoutProperties(props, ['message', 'values']);
-
-  var localize = context.localize;
-  var _localizeDebug = context._localizeDebug;
+  var localize = context.localize,
+      _localizeDebug = context._localizeDebug;
 
 
   var localized = message;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-localize",
-  "version": "2.0.1",
+  "version": "3.0.0-beta",
   "description": "A simple context wrapper and text localization component for localizing strings",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "2.0.1",
   "description": "A simple context wrapper and text localization component for localizing strings",
   "main": "build/index.js",
-  "files": ["build"],
+  "files": [
+    "build"
+  ],
   "scripts": {
     "build": "gulp build",
     "githooks": "gulp githooks",
@@ -32,10 +34,14 @@
     "util": "0.10.3"
   },
   "peerDependencies": {
-    "react": "^0.14.6 || 15.x"
+    "prop-types": ">=15",
+    "react": "^0.14.9 || >=15"
   },
   "devDependencies": {
-    "babel-preset-netflix-dea": "1.0.0-alpha.2",
+    "babel-preset-latest": "6.24.1",
+    "babel-plugin-add-module-exports": "0.2.1",
+    "babel-plugin-transform-react-jsx": "6.23.0",
+    "babel-preset-stage-2": "6.24.1",
     "babel-register": "6.24.1",
     "chai": "3.5.0",
     "eslint": "3.19.0",
@@ -49,7 +55,8 @@
     "gulp-symlink": "2.1.4",
     "gulp-util": "3.0.8",
     "mocha": "3.3.0",
-    "react": "0.14.6 || 15.x",
-    "react-dom": "0.14.6 || 15.x"
+    "prop-types": ">=15",
+    "react": "^0.14.9 || >=15",
+    "react-dom": "^0.14.9 || >=15"
   }
 }

--- a/src/Localization.jsx
+++ b/src/Localization.jsx
@@ -1,5 +1,6 @@
 import get from 'lodash.get';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import defaultLocalizer from './util/localize-formatter';
 
 const { element, bool, func, object } = PropTypes;

--- a/src/LocalizationConnector.jsx
+++ b/src/LocalizationConnector.jsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 export default (ComposedComponent) => {
   const LocalizeConnected = (props, context) => {

--- a/src/LocalizationWrapper.jsx
+++ b/src/LocalizationWrapper.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import get from 'lodash.get';
 import defaultLocalizer from './util/localize-formatter';
 

--- a/src/Text.jsx
+++ b/src/Text.jsx
@@ -12,7 +12,8 @@
  * Output: <span style={{ color: 'blue' }}>Hello, World!</span>
  */
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const { arrayOf, bool, func, string, any } = PropTypes;
 

--- a/tests/localize.js
+++ b/tests/localize.js
@@ -1,5 +1,6 @@
 import Chai from 'chai';
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOMServer from 'react-dom/server';
 const {expect} = Chai;
 import bundle from './data/egghead-bundle';
@@ -10,7 +11,7 @@ describe('Localize Context Value', () => {
 
   const BasicElement = React.createClass({
     contextTypes: {
-      localize: React.PropTypes.func
+      localize: PropTypes.func
     },
 
     render() {

--- a/tests/localize.js
+++ b/tests/localize.js
@@ -7,19 +7,19 @@ import bundle from './data/egghead-bundle';
 import Localization from '../src/Localization.jsx';
 import Text from '../src/Text.jsx';
 
+class BasicElement extends React.Component {
+  static contextTypes = {
+    localize: PropTypes.func
+  }
+
+  render() {
+    const { localize } = this.context;
+    const { customMessage, values } = this.props;
+    return <span>{localize(customMessage, values)}</span>
+  }
+};
+
 describe('Localize Context Value', () => {
-
-  const BasicElement = React.createClass({
-    contextTypes: {
-      localize: PropTypes.func
-    },
-
-    render() {
-      const { localize } = this.context;
-      const { customMessage, values } = this.props;
-      return <span>{localize(customMessage, values)}</span>
-    }
-  })
 
   it('renders out a standard message', () => {
     const messages = {

--- a/tools/test.js
+++ b/tools/test.js
@@ -4,7 +4,11 @@ import util from 'gulp-util';
 
 function test() {
   return gulp.src(['tests/**/*.js'], { read: false })
-    .pipe(mocha({ recursive: true, reporter: 'dot' }))
+    .pipe(mocha({
+      recursive: true,
+      reporter: 'dot',
+      require: ['babel-register']
+    }))
     .on('error', util.log);
 }
 


### PR DESCRIPTION
Making some React 15.5 compatible changes (mostly to ensure we can run on React 16 easier :)). Before merging would like to:

- [x] ensure older react versions still work (similar to react-access test matrix)
- [x] also remove `createClass` usage in one of the tests
- [x] maybe tidy up a few other things and update packages (or just let greenkeeper do that after?)